### PR TITLE
Fix a few errors I encountered, when trying to use this

### DIFF
--- a/common/src/download.rs
+++ b/common/src/download.rs
@@ -33,7 +33,15 @@ impl DownloadTask {
 	/// - `url` is the URL to download the file from.
 	/// - `path` is the path to which the file has to be saved.
 	pub async fn new(url: &str, path: &Path) -> Result<Self> {
-		let response = reqwest::get(url).await?;
+		let client = reqwest::Client::new();
+
+		const BLIMP_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+		let response = client
+			.get(url)
+			.header("User-Agent", format!("blimp/{}", BLIMP_VERSION))
+			.send()
+			.await?;
 		let total_size = response.content_length();
 		let stream = response.bytes_stream();
 

--- a/common/src/util.rs
+++ b/common/src/util.rs
@@ -76,7 +76,10 @@ pub fn decompress(src: &Path, dest: &Path) -> io::Result<()> {
 		Some("application/x-bzip2") => decompress_impl(BzDecoder::new(file), dest),
 		_ => Err(io::Error::new(
 			io::ErrorKind::Other,
-			"Invalid or unsupported archive format",
+			format!(
+				"Invalid or unsupported archive format: {}",
+				file_type.unwrap_or("<not detected>")
+			),
 		)),
 	}
 }


### PR DESCRIPTION
This fixes a few things:

One thing I encountered, while running `./cross/build.sh` was, that [binutils](https://ftp.gnu.org/gnu/binutils/binutils-2.42.tar.gz)

returned an error, when fetching it with blimp

The result to the  `reqwest::get` was 
```html
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>403 Forbidden</title>
</head><body>
<h1>Forbidden</h1>
<p>You don't have permission to access this resource.</p>
<hr>
<address>Apache/2.4.52 (Trisquel_GNU/Linux) Server at ftp.gnu.org Port 443</address>
</body></html>

```

I tried to use curl, and it succeeded, but when I set the User Agent to "" it failed there too. 

E.g. run

```bash
curl https://ftp.gnu.org/gnu/binutils/binutils-2.42.tar.gz
curl -A "" https://ftp.gnu.org/gnu/binutils/binutils-2.42.tar.gz
```

And you can see the difference.


This PR adds a commit, that uses the ` reqwest::Client` to add a User Agent to the request, so that it doesn't fail.
